### PR TITLE
Generalize GeoTiff functionality to work for GeoZarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ if (obj?.isSTAC()) {
   obj.getTemporalExtent();
   obj.getThumbnails();
   obj.getItemLinks();
-  obj.getDefaultGeoTIFF();
+  obj.getDefaultGeoFile();
   // ...
 }
 ```

--- a/src/mediatypes.js
+++ b/src/mediatypes.js
@@ -46,6 +46,30 @@ export const cogMediaTypes = [
 ];
 
 /**
+ * All web-optimized GeoZARR media types.
+ *
+ * @todo There are probably more variants, we may need to parse the media type completely.
+ * @type {Array.<string>}
+ */
+export const wozMediaTypes = ['application/vnd.zarr; version=3; profile=multiscales'];
+
+/**
+ * All ZARR media types.
+ *
+ * @type {Array.<string>}
+ */
+export const zarrMediaTypes = [
+  // See stac-fields for details
+  'application/vnd.zarr',
+  'application/vnd.zarr; version=2',
+  'application/vnd.zarr; version=3',
+  'application/vnd+zarr',
+  'application/vnd+zarr; version=2',
+  'application/vnd+zarr; version=3',
+  'application/x-zarr',
+].concat(wozMediaTypes);
+
+/**
  * All GeoTiff media types (including COG media types).
  *
  * @type {Array.<string>}

--- a/src/reference.js
+++ b/src/reference.js
@@ -1,5 +1,5 @@
 import { browserProtocols, toAbsolute } from './http.js';
-import { cogMediaTypes, geotiffMediaTypes, isMediaType } from './mediatypes.js';
+import { isMediaType } from './mediatypes.js';
 import { hasText, URI } from './utils.js';
 import STACObject from './object.js';
 import { browserImageTypes } from './mediatypes.js';

--- a/src/stac.js
+++ b/src/stac.js
@@ -1,4 +1,4 @@
-import { geotiffMediaTypes, isMediaType } from './mediatypes.js';
+import { cogMediaTypes, geotiffMediaTypes, isMediaType, wozMediaTypes, zarrMediaTypes } from './mediatypes.js';
 import { isObject, hasText } from './utils.js';
 import STACHypermedia from './hypermedia.js';
 import { getBest } from './locales.js';
@@ -114,15 +114,16 @@ class STAC extends STACHypermedia {
   }
 
   /**
-   * Determines the default GeoTiff asset for visualization.
+   * Determines the default GeoTIFF/GeoZARR asset for visualization.
    *
+   * @param {string} type The file type to look for, either `geotiff` or `geozarr`.
    * @param {boolean} httpOnly Return only GeoTiffs that can be accessed via HTTP(S)
-   * @param {boolean} cogOnly Return only COGs
-   * @returns {Asset} Default GeoTiff asset
-   * @see {rankGeoTIFFs}
+   * @param {boolean} optimizedOnly Return only optimized files (COG/WOZ)
+   * @returns {Asset} Default asset to visualize or `null` if no suitable asset is found.
+   * @see {rankGeoFiles}
    */
-  getDefaultGeoTIFF(httpOnly = true, cogOnly = false) {
-    let scores = this.rankGeoTIFFs(httpOnly, cogOnly);
+  getDefaultGeoFile(type, httpOnly = true, optimizedOnly = false) {
+    let scores = this.rankGeoFiles(type, httpOnly, optimizedOnly);
     return scores[0]?.asset;
   }
 
@@ -140,12 +141,12 @@ class STAC extends STACHypermedia {
    * Returns a relative addition to the score.
    * Negative values subtract from the score.
    *
-   * @callback STAC~rankGeoTIFFs
+   * @callback STAC~rankGeoFiles
    * @param {Asset} asset The asset to calculate the score for.
    */
 
   /**
-   * Ranks the GeoTiff assets for visualization purposes.
+   * Ranks the GeoTiff/GeoZarr assets for visualization purposes.
    *
    * The score factors can be found below:
    * - Roles/Keys (by default) - if multiple roles apply only the highest score is added:
@@ -155,17 +156,29 @@ class STAC extends STACHypermedia {
    *   - data => +1
    *   - none of the above => no change
    * - Other factors:
-   *   - media type is COG: +2 (if cogOnly = false)
+   *   - media type is COG/WOZ: +2 (if optimizedOnly = false)
    *   - has RGB bands: +1
    *   - additionalCriteria: +/- a custom value
    *
+   * @param {string} type The file type to rank for, either `geotiff` or `geozarr`.
    * @param {boolean} httpOnly Return only GeoTiffs that can be accessed via HTTP(S)
-   * @param {boolean} cogOnly Return only COGs
+   * @param {boolean} optimizedOnly Return only optimized files (COG/WOZ)
    * @param {Object.<string, number>} roleScores Roles (and keys) considered for the scoring. They key is the role name, the value is the score. Higher is better. Defaults to the roles and scores detailed above. An empty object disables role-based scoring.
-   * @param {STAC~rankGeoTIFFs} additionalCriteria A function to customize the score by adding/subtracting.
-   * @returns {Array.<AssetScore>} GeoTiff assets sorted by score in descending order.
+   * @param {STAC~rankGeoFiles} additionalCriteria A function to customize the score by adding/subtracting.
+   * @returns {Array.<AssetScore>} GeoTiff/GeoZarr assets sorted by score in descending order.
    */
-  rankGeoTIFFs(httpOnly = true, cogOnly = false, roleScores = null, additionalCriteria = null) {
+  rankGeoFiles(type, httpOnly = true, optimizedOnly = false, roleScores = null, additionalCriteria = null) {
+    const mediaTypes = {
+      geotiff: geotiffMediaTypes,
+      geozarr: zarrMediaTypes,
+    };
+    const optimizedTypes = {
+      geotiff: cogMediaTypes,
+      geozarr: wozMediaTypes,
+    };
+    if (!(type in mediaTypes)) {
+      return [];
+    }
     if (!isObject(roleScores)) {
       roleScores = {
         data: 1,
@@ -175,9 +188,10 @@ class STAC extends STACHypermedia {
       };
     }
     let scores = [];
-    let assets = this.getAssetsByTypes(geotiffMediaTypes);
+    let assets = this.getAssetsByTypes(mediaTypes[type]);
     if (httpOnly) {
-      assets = assets.filter((asset) => asset.isHTTP() && (!cogOnly || asset.isCOG()));
+      // todo: This doesn't cater for cases where e.g. S3 is the main asset and the HTTP asset is the alternate asset.
+      assets = assets.filter((asset) => asset.isHTTP() && (!optimizedOnly || asset.isType(optimizedTypes[type])));
     }
     let roles = Object.entries(roleScores);
     for (let asset of assets) {
@@ -190,7 +204,7 @@ class STAC extends STACHypermedia {
           score += Math.max(...result); // Add the highest of the scores
         }
       }
-      if (!cogOnly && asset.isCOG()) {
+      if (!optimizedOnly && asset.isType(optimizedTypes[type])) {
         score += 2;
       }
       if (asset.findVisualBands()) {

--- a/tests/asset.test.js
+++ b/tests/asset.test.js
@@ -117,16 +117,6 @@ test('getAbsoluteUrl', () => {
   expect(def.getAbsoluteUrl()).toBeNull();
 });
 
-test('isGeoTIFF', () => {
-  expect(asset.isGeoTIFF()).toBeTruthy();
-  expect(def.isGeoTIFF()).toBeTruthy();
-});
-
-test('isCOG', () => {
-  expect(asset.isCOG()).toBeTruthy();
-  expect(def.isCOG()).toBeTruthy();
-});
-
 test('isDefinition', () => {
   expect(asset.isDefinition()).toBeFalsy();
   expect(def.isDefinition()).toBeTruthy();

--- a/tests/examples/item-s2-eopf-zarr.json
+++ b/tests/examples/item-s2-eopf-zarr.json
@@ -1,0 +1,540 @@
+{
+  "id": "S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412",
+  "bbox": [
+    -29.9137117322073,
+    71.17252546897744,
+    -27.820392533872365,
+    72.09194779038121
+  ],
+  "type": "Feature",
+  "links": [
+    {
+      "rel": "collection",
+      "type": "application/json",
+      "href": "https://api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a"
+    },
+    {
+      "rel": "parent",
+      "type": "application/json",
+      "href": "https://api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://api.explorer.eopf.copernicus.eu/stac/"
+    },
+    {
+      "rel": "self",
+      "type": "application/geo+json",
+      "href": "https://api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a/items/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412"
+    },
+    {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5270/S2_-znk9xsj"
+    },
+    {
+      "rel": "license",
+      "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+      "type": "application/pdf",
+      "title": "Legal notice on the use of Copernicus Sentinel Data and Service Information"
+    },
+    {
+      "rel": "store",
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr",
+      "type": "application/octet-stream",
+      "title": "Zarr Store"
+    },
+    {
+      "rel": "viewer",
+      "href": "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412/viewer",
+      "type": "text/html",
+      "title": "Viewer for S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412"
+    },
+    {
+      "rel": "xyz",
+      "href": "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412/tiles/WebMercatorQuad/{z}/{x}/{y}.png?rescale=0%2C1&color_formula=gamma%20rgb%201.3%2C%20sigmoidal%20rgb%206%200.1%2C%20saturation%201.2&variables=%2Fmeasurements%2Freflectance%3Ab04&variables=%2Fmeasurements%2Freflectance%3Ab03&variables=%2Fmeasurements%2Freflectance%3Ab02&bidx=1",
+      "type": "image/png",
+      "title": "Sentinel-2 L2A True Color"
+    },
+    {
+      "rel": "tilejson",
+      "href": "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412/WebMercatorQuad/tilejson.json?rescale=0%2C1&color_formula=gamma%20rgb%201.3%2C%20sigmoidal%20rgb%206%200.1%2C%20saturation%201.2&variables=%2Fmeasurements%2Freflectance%3Ab04&variables=%2Fmeasurements%2Freflectance%3Ab03&variables=%2Fmeasurements%2Freflectance%3Ab02&bidx=1",
+      "type": "application/json",
+      "title": "TileJSON for S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412"
+    },
+    {
+      "rel": "via",
+      "href": "https://explorer.eopf.copernicus.eu/collections/sentinel-2-l2a/items/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412",
+      "title": "EOPF Explorer"
+    },
+    {
+      "rel": "derived_from",
+      "href": "https://stac.core.eopf.eodc.eu/collections/sentinel-2-l2a/items/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412",
+      "type": "application/json",
+      "title": "Derived from original Zarr STAC item"
+    }
+  ],
+  "assets": {
+    "AOT_10m": {
+      "gsd": 10,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/quality/atmosphere/r10m/aot",
+      "type": "application/vnd.zarr; version=3",
+      "roles": [
+        "data"
+      ],
+      "title": "Aerosol optical thickness (AOT)",
+      "nodata": 0,
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/quality/atmosphere/r10m/aot",
+          "storage:scheme": {
+            "region": "de",
+            "platform": "OVHcloud",
+            "requester_pays": false
+          }
+        }
+      },
+      "data_type": "uint16",
+      "description": "Aerosol Optical Thickness map at 10m (for 550nm) resampled from 20m AOT map",
+      "raster:scale": 0.001,
+      "raster:offset": 0
+    },
+    "SCL_20m": {
+      "gsd": 20,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/conditions/mask/l2a_classification/r20m/scl",
+      "type": "application/vnd.zarr; version=3",
+      "roles": [
+        "data"
+      ],
+      "title": "Scene classification map (SCL)",
+      "nodata": 0,
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/conditions/mask/l2a_classification/r20m/scl",
+          "storage:scheme": {
+            "region": "de",
+            "platform": "OVHcloud",
+            "requester_pays": false
+          }
+        }
+      },
+      "data_type": "uint8",
+      "description": "scene classification map at 20m",
+      "raster:scale": 1,
+      "raster:offset": 0
+    },
+    "WVP_10m": {
+      "gsd": 10,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/quality/atmosphere/r10m/wvp",
+      "type": "application/vnd.zarr; version=3",
+      "roles": [
+        "data"
+      ],
+      "title": "Water vapour (WVP)",
+      "nodata": 0,
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/quality/atmosphere/r10m/wvp",
+          "storage:scheme": {
+            "region": "de",
+            "platform": "OVHcloud",
+            "requester_pays": false
+          }
+        }
+      },
+      "data_type": "uint16",
+      "description": "Water Vapour Content map at 10m",
+      "raster:scale": 0.001,
+      "raster:offset": 0
+    },
+    "thumbnail": {
+      "href": "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412/preview?format=png&rescale=0%2C1&color_formula=gamma%20rgb%201.3%2C%20sigmoidal%20rgb%206%200.1%2C%20saturation%201.2&variables=%2Fmeasurements%2Freflectance%3Ab04&variables=%2Fmeasurements%2Freflectance%3Ab03&variables=%2Fmeasurements%2Freflectance%3Ab02&bidx=1",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ],
+      "title": "Sentinel-2 L2A True Color Preview"
+    },
+    "reflectance": {
+      "gsd": 10,
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/measurements/reflectance",
+      "type": "application/vnd.zarr; version=3; profile=multiscales",
+      "bands": [
+        {
+          "gsd": 20,
+          "name": "b01",
+          "description": "Coastal aerosol (band 1)",
+          "eo:common_name": "coastal",
+          "eo:center_wavelength": 0.443,
+          "eo:full_width_half_max": 0.027
+        },
+        {
+          "gsd": 10,
+          "name": "b02",
+          "description": "Blue (band 2)",
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.49,
+          "eo:full_width_half_max": 0.098
+        },
+        {
+          "gsd": 10,
+          "name": "b03",
+          "description": "Green (band 3)",
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.56,
+          "eo:full_width_half_max": 0.045
+        },
+        {
+          "gsd": 10,
+          "name": "b04",
+          "description": "Red (band 4)",
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.665,
+          "eo:full_width_half_max": 0.038
+        },
+        {
+          "gsd": 20,
+          "name": "b05",
+          "description": "Red edge 1 (band 5)",
+          "eo:common_name": "rededge071",
+          "eo:center_wavelength": 0.704,
+          "eo:full_width_half_max": 0.019
+        },
+        {
+          "gsd": 20,
+          "name": "b06",
+          "description": "Red edge 2 (band 6)",
+          "eo:common_name": "rededge075",
+          "eo:center_wavelength": 0.74,
+          "eo:full_width_half_max": 0.018
+        },
+        {
+          "gsd": 20,
+          "name": "b07",
+          "description": "Red edge 3 (band 7)",
+          "eo:common_name": "rededge078",
+          "eo:center_wavelength": 0.783,
+          "eo:full_width_half_max": 0.028
+        },
+        {
+          "gsd": 10,
+          "name": "b08",
+          "description": "NIR 1 (band 8)",
+          "eo:common_name": "nir",
+          "eo:center_wavelength": 0.842,
+          "eo:full_width_half_max": 0.145
+        },
+        {
+          "gsd": 60,
+          "name": "b09",
+          "description": "NIR 3 (band 9)",
+          "eo:common_name": "nir09",
+          "eo:center_wavelength": 0.945,
+          "eo:full_width_half_max": 0.026
+        },
+        {
+          "gsd": 20,
+          "name": "b11",
+          "description": "SWIR 1 (band 11)",
+          "eo:common_name": "swir16",
+          "eo:center_wavelength": 1.61,
+          "eo:full_width_half_max": 0.143
+        },
+        {
+          "gsd": 20,
+          "name": "b12",
+          "description": "SWIR 2 (band 12)",
+          "eo:common_name": "swir22",
+          "eo:center_wavelength": 2.19,
+          "eo:full_width_half_max": 0.242
+        },
+        {
+          "gsd": 20,
+          "name": "b8a",
+          "description": "NIR 2 (band 8A)",
+          "eo:common_name": "nir08",
+          "eo:center_wavelength": 0.865,
+          "eo:full_width_half_max": 0.033
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ],
+      "title": "Surface Reflectance",
+      "alternate": {
+        "s3": {
+          "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/measurements/reflectance",
+          "storage:scheme": {
+            "region": "de",
+            "platform": "OVHcloud",
+            "requester_pays": false
+          }
+        }
+      },
+      "proj:code": "EPSG:32626",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "cube:variables": {
+        "b01": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Coastal aerosol (band 1)"
+        },
+        "b02": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Blue (band 2)"
+        },
+        "b03": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Green (band 3)"
+        },
+        "b04": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red (band 4)"
+        },
+        "b05": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red edge 1 (band 5)"
+        },
+        "b06": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red edge 2 (band 6)"
+        },
+        "b07": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "Red edge 3 (band 7)"
+        },
+        "b08": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "NIR 1 (band 8)"
+        },
+        "b09": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "NIR 3 (band 9)"
+        },
+        "b11": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "SWIR 1 (band 11)"
+        },
+        "b12": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "SWIR 2 (band 12)"
+        },
+        "b8a": {
+          "type": "data",
+          "dimensions": [
+            "y",
+            "x"
+          ],
+          "description": "NIR 2 (band 8A)"
+        }
+      },
+      "cube:dimensions": {
+        "x": {
+          "axis": "x",
+          "type": "spatial",
+          "reference_system": "EPSG:32626"
+        },
+        "y": {
+          "axis": "y",
+          "type": "spatial",
+          "reference_system": "EPSG:32626"
+        }
+      }
+    }
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -27.820392533872365,
+          72.09194779038121
+        ],
+        [
+          -27.956671091666312,
+          72.03067349580736
+        ],
+        [
+          -28.22861471164142,
+          71.90544009340364
+        ],
+        [
+          -28.50643784717797,
+          71.78215008131905
+        ],
+        [
+          -28.7768101232578,
+          71.65756888493422
+        ],
+        [
+          -29.04328152583893,
+          71.53251236461928
+        ],
+        [
+          -29.298700746291725,
+          71.40525276447413
+        ],
+        [
+          -29.56053793136547,
+          71.2800220854421
+        ],
+        [
+          -29.778871100700574,
+          71.17252546897744
+        ],
+        [
+          -29.9137117322073,
+          72.07787733115468
+        ],
+        [
+          -27.820392533872365,
+          72.09194779038121
+        ]
+      ]
+    ]
+  },
+  "collection": "sentinel-2-l2a",
+  "properties": {
+    "gsd": 10,
+    "created": "2026-03-18T23:55:05.090393Z",
+    "mission": "Sentinel-2",
+    "sci:doi": "10.5270/S2_-znk9xsj",
+    "updated": "2026-03-18T23:55:05.090393Z",
+    "datetime": "2026-03-18T14:28:51.024000Z",
+    "platform": "sentinel-2a",
+    "grid:code": "MGRS-26WME",
+    "proj:bbox": [
+      -29.9137117322073,
+      71.17252546897744,
+      -27.820392533872365,
+      72.09194779038121
+    ],
+    "proj:code": "EPSG:32626",
+    "providers": [
+      {
+        "url": "https://commission.europa.eu/",
+        "name": "European Commission",
+        "roles": [
+          "licensor"
+        ]
+      },
+      {
+        "url": "https://sentinel.esa.int/web/sentinel/missions/sentinel-2",
+        "name": "ESA",
+        "roles": [
+          "producer",
+          "processor"
+        ]
+      },
+      {
+        "url": "https://zarr.eopf.copernicus.eu/",
+        "name": "EOPF Sentinel Zarr Samples Service",
+        "roles": [
+          "host",
+          "processor"
+        ]
+      }
+    ],
+    "published": "2026-03-18T23:55:05.090393Z",
+    "deprecated": false,
+    "instruments": [
+      "msi"
+    ],
+    "end_datetime": "2026-03-18T14:28:51.024000Z",
+    "product:type": "S02MSIL2A",
+    "constellation": "sentinel-2",
+    "eo:snow_cover": 0.02206,
+    "mgrs:utm_zone": 26,
+    "proj:centroid": {
+      "lat": 71.78348,
+      "lon": -29.17697
+    },
+    "eo:cloud_cover": 93.700892,
+    "start_datetime": "2026-03-18T14:28:51.024000Z",
+    "sat:orbit_state": "descending",
+    "eopf:datatake_id": "GS2A_20260318T142851_056078_N05.12",
+    "mgrs:grid_square": "ME",
+    "processing:level": "L2A",
+    "view:sun_azimuth": 188.21719773539,
+    "eopf:datastrip_id": "S2A_OPER_MSI_L2A_DS_2APS_20260318T224412_S20260318T143204_N05.12",
+    "mgrs:latitude_band": "W",
+    "processing:lineage": "systematic",
+    "processing:version": "05.12",
+    "product:timeliness": "PT3H",
+    "sat:absolute_orbit": 56078,
+    "sat:relative_orbit": 139,
+    "view:sun_elevation": 72.5743583775765,
+    "processing:facility": "ESA",
+    "processing:software": {
+      "EOPF-CPM": "2.6.2"
+    },
+    "eopf:instrument_mode": "INS-NOBS",
+    "product:timeliness_category": "NRT",
+    "sat:platform_international_designator": "2015-028A"
+  },
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/processing/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/product/v0.1.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+    "https://cs-si.github.io/eopf-stac-extension/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/raster/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/storage/v2.0.0/schema.json"
+  ]
+}

--- a/tests/item.test.js
+++ b/tests/item.test.js
@@ -4,7 +4,9 @@ import Link from '../src/link';
 import Asset from '../src/asset';
 import create from '../src/index';
 
-let json = JSON.parse(fs.readFileSync('./tests/examples/item.json'));
+const loadJson = (path) => JSON.parse(fs.readFileSync(path));
+
+let json = loadJson('./tests/examples/item.json');
 let item = new Item(json);
 let bbox = [172.91, 1.34, 172.95, 1.36];
 let dtDate = new Date(Date.UTC(2020, 11, 14, 18, 2, 31));
@@ -14,15 +16,18 @@ let collectionLink = item.links.find((link) => link.rel === 'collection');
 let rootLink = item.links.find((link) => link.rel === 'root');
 let parentLink = item.links.find((link) => link.rel === 'parent');
 
-let json2 = JSON.parse(fs.readFileSync('./tests/examples/item-s2.json'));
+let json2 = loadJson('./tests/examples/item-s2.json');
 let item2 = new Item(json2);
 let dtStr2 = '2023-02-27T14:47:44Z';
 let dtDate2 = new Date(Date.UTC(2023, 1, 27, 14, 47, 44));
 
 let url = 'https://example.com/20201211_223832_CS2/item.json';
 
-let json2Old = JSON.parse(fs.readFileSync('./tests/examples/item-s2-old.json'));
+let json2Old = loadJson('./tests/examples/item-s2-old.json');
 let item2Old = create(json2Old, true, true);
+
+let jsonZarr = loadJson('./tests/examples/item-s2-eopf-zarr.json');
+let itemZarr = new Item(jsonZarr);
 
 describe('Migration', () => {
   test('stac_version', () => {
@@ -184,47 +189,74 @@ describe('links', () => {
 });
 
 describe('rankGeoFiles', () => {
-  test('default', () => {
+  test('invalid type returns empty array', () => {
+    expect(item.rankGeoFiles('invalid')).toEqual([]);
+  });
+
+  test('default (geotiff)', () => {
     let ranks = item.rankGeoFiles('geotiff');
     expect(ranks.length).toBe(3);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([5, 4, 0]);
   });
 
-  test('not httpOnly', () => {
+  test('default (zarr)', () => {
+    let ranks = itemZarr.rankGeoFiles('geozarr');
+    expect(ranks.length).toBe(4);
+    expect(ranks.map((r) => r.asset.getKey())).toEqual(['reflectance', 'AOT_10m', 'SCL_20m', 'WVP_10m']);
+    expect(ranks.map((r) => r.score)).toEqual([4, 1, 1, 1]);
+  });
+
+  test('not httpOnly (geotiff)', () => {
     let ranks = item.rankGeoFiles('geotiff', false);
     expect(ranks.length).toBe(4);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic', 's3', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([5, 4, 3, 0]);
   });
 
-  test('optimizedOnly', () => {
+  test('optimizedOnly (geotiff)', () => {
     let ranks = item.rankGeoFiles('geotiff', true, true);
     expect(ranks.length).toBe(2);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic']);
     expect(ranks.map((r) => r.score)).toEqual([3, 2]);
   });
 
-  test('with different roles', () => {
+  test('optimizedOnly (zarr)', () => {
+    let ranks = itemZarr.rankGeoFiles('geozarr', true, true);
+    expect(ranks.length).toBe(1);
+    expect(ranks[0].asset.getKey()).toEqual('reflectance');
+    expect(ranks[0].score).toEqual(2);
+  });
+
+  test('with different roles (geotiff)', () => {
     let ranks = item.rankGeoFiles('geotiff', true, false, { analytic: 5 });
     expect(ranks.length).toBe(3);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['analytic', 'visual', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([8, 3, 0]);
   });
 
-  test('with callback', () => {
+  test('with callback (geotiff)', () => {
     let ranks = item.rankGeoFiles('geotiff', true, false, null, (asset) => (Array.isArray(asset.bands) ? 5 : -5));
     expect(ranks.length).toBe(3);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([10, 9, -5]);
   });
 
-  test('getDefaultGeoFile', () => {
+  test('getDefaultGeoFile (geotiff)', () => {
     let asset = item.getDefaultGeoFile('geotiff');
     expect(asset).not.toBeNull();
     expect(asset.getKey()).toEqual('visual');
     expect(asset.href).toEqual('./20201211_223832_CS2.tif');
     expect(asset.getAbsoluteUrl()).toEqual('https://example.com/20201211_223832_CS2/20201211_223832_CS2.tif');
+  });
+
+  test('getDefaultGeoFile (zarr)', () => {
+    let asset = itemZarr.getDefaultGeoFile('geozarr');
+    expect(asset).not.toBeNull();
+    expect(asset.getKey()).toEqual('reflectance');
+    expect(asset.href).toEqual(
+      'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20260318T142851_N0512_R139_T26WME_20260318T224412.zarr/measurements/reflectance',
+    );
   });
 });
 

--- a/tests/item.test.js
+++ b/tests/item.test.js
@@ -178,44 +178,44 @@ describe('links', () => {
   });
 });
 
-describe('rankGeoTIFFs', () => {
+describe('rankGeoFiles', () => {
   test('default', () => {
-    let ranks = item.rankGeoTIFFs();
+    let ranks = item.rankGeoFiles('geotiff');
     expect(ranks.length).toBe(3);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([5, 4, 0]);
   });
 
   test('not httpOnly', () => {
-    let ranks = item.rankGeoTIFFs(false);
+    let ranks = item.rankGeoFiles('geotiff', false);
     expect(ranks.length).toBe(4);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic', 's3', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([5, 4, 3, 0]);
   });
 
-  test('cogOnly', () => {
-    let ranks = item.rankGeoTIFFs(true, true);
+  test('optimizedOnly', () => {
+    let ranks = item.rankGeoFiles('geotiff', true, true);
     expect(ranks.length).toBe(2);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic']);
     expect(ranks.map((r) => r.score)).toEqual([3, 2]);
   });
 
   test('with different roles', () => {
-    let ranks = item.rankGeoTIFFs(true, false, { analytic: 5 });
+    let ranks = item.rankGeoFiles('geotiff', true, false, { analytic: 5 });
     expect(ranks.length).toBe(3);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['analytic', 'visual', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([8, 3, 0]);
   });
 
   test('with callback', () => {
-    let ranks = item.rankGeoTIFFs(true, false, null, (asset) => (Array.isArray(asset.bands) ? 5 : -5));
+    let ranks = item.rankGeoFiles('geotiff', true, false, null, (asset) => (Array.isArray(asset.bands) ? 5 : -5));
     expect(ranks.length).toBe(3);
     expect(ranks.map((r) => r.asset.getKey())).toEqual(['visual', 'analytic', 'udm']);
     expect(ranks.map((r) => r.score)).toEqual([10, 9, -5]);
   });
 
-  test('getDefaultGeoTIFF', () => {
-    let asset = item.getDefaultGeoTIFF();
+  test('getDefaultGeoFile', () => {
+    let asset = item.getDefaultGeoFile('geotiff');
     expect(asset).not.toBeNull();
     expect(asset.getKey()).toEqual('visual');
     expect(asset.href).toEqual('./20201211_223832_CS2.tif');


### PR DESCRIPTION
- Remove isGeoTIFF and isCOG from Asset (and Links)
- Rename getDefaultGeoTIFF to getDefaultGeoFile, adding a required type parameter
- Rename rankGeoTIFFs to rankGeoFile, adding a required type parameter
- Add media types for Zarr and WOZ

ToDo: Add tests